### PR TITLE
Remove BullaFrendLend from invoice provider adapter

### DIFF
--- a/contracts/BullaClaimV2InvoiceProviderAdapterV2.sol
+++ b/contracts/BullaClaimV2InvoiceProviderAdapterV2.sol
@@ -7,25 +7,22 @@ import {IBullaClaimCore} from "bulla-contracts-v2/src/interfaces/IBullaClaimCore
 import {Claim, Status} from "bulla-contracts-v2/src/types/Types.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {console} from "../lib/forge-std/src/console.sol";
-import {IBullaFrendLendV2, Loan} from "bulla-contracts-v2/src/interfaces/IBullaFrendLendV2.sol";
 import {IBullaInvoice, Invoice as BullaInvoice} from "bulla-contracts-v2/src/interfaces/IBullaInvoice.sol";
 
 contract BullaClaimV2InvoiceProviderAdapterV2 is IInvoiceProviderAdapterV2 {
     IBullaClaimV2 private bullaClaimV2;
-    IBullaFrendLendV2 private immutable bullaFrendLend;
     IBullaInvoice private immutable bullaInvoice;
 
     // Cache for controller addresses (immutable once set)
     mapping(uint256 => address) private controllerCache;
     mapping(uint256 => uint256) private impairmentGracePeriodCache;
     mapping(uint256 => bool) private isCached;
-    
+
     error InexistentInvoice();
     error UnknownClaimType();
 
-    constructor(address _bullaClaimV2Address, address _bullaFrendLend, address _bullaInvoice) {
+    constructor(address _bullaClaimV2Address, address _bullaInvoice) {
         bullaClaimV2 = IBullaClaimV2(_bullaClaimV2Address);
-        bullaFrendLend = IBullaFrendLendV2(_bullaFrendLend);
         bullaInvoice = IBullaInvoice(_bullaInvoice);
     }
 
@@ -50,7 +47,7 @@ contract BullaClaimV2InvoiceProviderAdapterV2 is IInvoiceProviderAdapterV2 {
         if (isCached[invoiceId]) {
             return controllerCache[invoiceId];
         }
-        
+
         revert InexistentInvoice();
     }
 
@@ -80,34 +77,12 @@ contract BullaClaimV2InvoiceProviderAdapterV2 is IInvoiceProviderAdapterV2 {
             });
 
             return invoice;
-        } else if (controller == address(bullaFrendLend)) {
-            Loan memory loan = bullaFrendLend.getLoan(invoiceId);
-            // Cache interest computation state to avoid repeated access
-            uint256 totalGrossInterestPaid = loan.interestComputationState.totalGrossInterestPaid;
-            uint256 accruedInterest = loan.interestComputationState.accruedInterest;
-            
-            paidAmount = loan.paidAmount + totalGrossInterestPaid;
-            invoiceAmount = loan.claimAmount + accruedInterest + totalGrossInterestPaid;
-
-            Invoice memory invoice = Invoice({
-                invoiceAmount: invoiceAmount,
-                creditor: loan.creditor,
-                debtor: loan.debtor,
-                dueDate: loan.dueBy,
-                tokenAddress: loan.token,
-                paidAmount: paidAmount,
-                isCanceled: loan.status == Status.Rejected || loan.status == Status.Rescinded,
-                isPaid: loan.status == Status.Paid,
-                impairmentGracePeriod: impairmentGracePeriodCache[invoiceId]
-            });
-
-            return invoice;
         } else if (controller == address(bullaInvoice)) {
             BullaInvoice memory _bullaInvoice = bullaInvoice.getInvoice(invoiceId);
             // Cache interest computation state to avoid repeated access
             uint256 totalGrossInterestPaid = _bullaInvoice.interestComputationState.totalGrossInterestPaid;
             uint256 accruedInterest = _bullaInvoice.interestComputationState.accruedInterest;
-            
+
             paidAmount = _bullaInvoice.paidAmount + totalGrossInterestPaid;
             invoiceAmount = _bullaInvoice.claimAmount + accruedInterest + totalGrossInterestPaid;
 
@@ -131,19 +106,16 @@ contract BullaClaimV2InvoiceProviderAdapterV2 is IInvoiceProviderAdapterV2 {
 
     function getInvoiceContractAddress(uint256 tokenId) external view returns (address) {
         address controller = _getCachedController(tokenId);
-        
+
         return controller == address(0) ? address(bullaClaimV2) : controller;
     }
 
     function getSetPaidInvoiceTarget(uint256 invoiceId) external view returns (address target, bytes4 selector) {
         address controller = _getCachedController(invoiceId);
-        
+
         if (controller == address(0)) {
             // BullaClaimV2 - use setPaidClaim function
             return (address(bullaClaimV2), IBullaClaimCore.setPaidClaimCallback.selector);
-        } else if (controller == address(bullaFrendLend)) {
-            // BullaFrendLend - use setPaidLoan function
-            return (address(bullaFrendLend), IBullaFrendLendV2.setPaidLoanCallback.selector);
         } else if (controller == address(bullaInvoice)) {
             // BullaInvoice - use setPaidInvoice function
             return (address(bullaInvoice), IBullaInvoice.setPaidInvoiceCallback.selector);
@@ -156,8 +128,6 @@ contract BullaClaimV2InvoiceProviderAdapterV2 is IInvoiceProviderAdapterV2 {
         address controller = _getCachedController(invoiceId);
         if (controller == address(0)) {
             return (address(bullaClaimV2), IBullaClaimCore.impairClaim.selector);
-        } else if (controller == address(bullaFrendLend)) {
-            return (address(bullaFrendLend), IBullaFrendLendV2.impairLoan.selector);
         } else if (controller == address(bullaInvoice)) {
             return (address(bullaInvoice), IBullaInvoice.impairInvoice.selector);
         } else {

--- a/script/DeployAdapter.s.sol
+++ b/script/DeployAdapter.s.sol
@@ -9,23 +9,20 @@ contract DeployAdapter is Script {
     function run() external {
         // Load configuration from environment
         address bullaClaim = vm.envAddress("BULLA_CLAIM");
-        address bullaFrendLend = vm.envOr("BULLA_FREND_LEND_ADDRESS", address(0));
         address bullaInvoice = vm.envOr("BULLA_INVOICE_ADDRESS", address(0));
-        
+
         uint256 deployerPrivateKey = vm.envUint("DEPLOY_PK");
         address deployer = vm.addr(deployerPrivateKey);
-        
+
         console.log("Deploying BullaClaimV2InvoiceProviderAdapterV2 with:");
         console.log("- Deployer:", deployer);
         console.log("- BullaClaim:", bullaClaim);
-        console.log("- BullaFrendLend:", bullaFrendLend);
         console.log("- BullaInvoice:", bullaInvoice);
-        
+
         vm.startBroadcast(deployerPrivateKey);
-        
+
         BullaClaimV2InvoiceProviderAdapterV2 adapter = new BullaClaimV2InvoiceProviderAdapterV2(
             bullaClaim,
-            bullaFrendLend,
             bullaInvoice
         );
         

--- a/script/DeployBullaFactoring.s.sol
+++ b/script/DeployBullaFactoring.s.sol
@@ -28,7 +28,6 @@ contract DeployBullaFactoring is Script {
         address factoringPermissionsAddress;
         address depositPermissionsAddress;
         address redeemPermissionsAddress;
-        address bullaFrendLendAddress;
         address bullaInvoiceAddress;
         address bullaFactoringAddress;
         address insurer;
@@ -64,7 +63,6 @@ contract DeployBullaFactoring is Script {
             console.log("Deploying BullaClaimV2InvoiceProviderAdapterV2...");
             BullaClaimV2InvoiceProviderAdapterV2 adapter = new BullaClaimV2InvoiceProviderAdapterV2(
                 config.bullaClaim,
-                config.bullaFrendLendAddress,
                 config.bullaInvoiceAddress
             );
             config.bullaClaimInvoiceProviderAdapterAddress = address(adapter);
@@ -158,7 +156,6 @@ contract DeployBullaFactoring is Script {
         config.factoringPermissionsAddress = vm.envOr("FACTORING_PERMISSIONS_ADDRESS", address(0));
         config.depositPermissionsAddress = vm.envOr("DEPOSIT_PERMISSIONS_ADDRESS", address(0));
         config.redeemPermissionsAddress = vm.envOr("REDEEM_PERMISSIONS_ADDRESS", address(0));
-        config.bullaFrendLendAddress = vm.envOr("BULLA_FREND_LEND_ADDRESS", address(0));
         config.bullaInvoiceAddress = vm.envOr("BULLA_INVOICE_ADDRESS", address(0));
         config.bullaFactoringAddress = vm.envOr("BULLA_FACTORING_ADDRESS", address(0));
         config.insurer = vm.envOr("INSURER_ADDRESS", address(0));

--- a/script/DeployBullaFactoringFactory.s.sol
+++ b/script/DeployBullaFactoringFactory.s.sol
@@ -13,7 +13,6 @@ contract DeployBullaFactoringFactory is Script {
     struct FactoryConfig {
         address bullaClaim;
         address bullaDao;
-        address bullaFrendLendAddress;
         address bullaInvoiceAddress;
         address bullaClaimInvoiceProviderAdapterAddress;
         uint16 protocolFeeBps;
@@ -32,7 +31,6 @@ contract DeployBullaFactoringFactory is Script {
         console.log("Factory Config:");
         console.log("- BullaClaim:", config.bullaClaim);
         console.log("- BullaDao:", config.bullaDao);
-        console.log("- BullaFrendLend:", config.bullaFrendLendAddress);
         console.log("- ProtocolFeeBps:", config.protocolFeeBps);
         
         vm.startBroadcast(deployerPrivateKey);
@@ -42,7 +40,6 @@ contract DeployBullaFactoringFactory is Script {
             console.log("Deploying BullaClaimV2InvoiceProviderAdapterV2...");
             BullaClaimV2InvoiceProviderAdapterV2 adapter = new BullaClaimV2InvoiceProviderAdapterV2(
                 config.bullaClaim,
-                config.bullaFrendLendAddress,
                 config.bullaInvoiceAddress
             );
             config.bullaClaimInvoiceProviderAdapterAddress = address(adapter);
@@ -85,7 +82,6 @@ contract DeployBullaFactoringFactory is Script {
         // Load from environment variables (set by the TypeScript wrapper)
         config.bullaClaim = vm.envAddress("BULLA_CLAIM");
         config.bullaDao = vm.envAddress("BULLA_DAO");
-        config.bullaFrendLendAddress = vm.envOr("BULLA_FREND_LEND_ADDRESS", address(0));
         config.bullaInvoiceAddress = vm.envOr("BULLA_INVOICE_ADDRESS", address(0));
         config.bullaClaimInvoiceProviderAdapterAddress = vm.envOr("BULLA_CLAIM_INVOICE_PROVIDER_ADAPTER_ADDRESS", address(0));
         config.protocolFeeBps = uint16(vm.envUint("PROTOCOL_FEE_BPS"));

--- a/test/foundry/CommonSetup.t.sol
+++ b/test/foundry/CommonSetup.t.sol
@@ -17,8 +17,6 @@ import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "contracts/interfaces/IBullaFactoring.sol";
 import './helpers/TestHelpers.sol';
 import {IBullaClaimV2, LockState} from "bulla-contracts-v2/src/interfaces/IBullaClaimV2.sol";
-import {IBullaFrendLendV2} from "bulla-contracts-v2/src/interfaces/IBullaFrendLendV2.sol";
-import {BullaFrendLendV2} from "bulla-contracts-v2/src/BullaFrendLendV2.sol";
 import {BullaControllerRegistry} from "bulla-contracts-v2/src/BullaControllerRegistry.sol";
 import {BullaClaimV2} from "bulla-contracts-v2/src/BullaClaimV2.sol";
 import {IBullaInvoice} from "bulla-contracts-v2/src/interfaces/IBullaInvoice.sol";
@@ -41,7 +39,6 @@ contract CommonSetup is Test, BatchTestHelpers {
     BullaControllerRegistry public bullaControllerRegistry;
     BullaApprovalRegistry public bullaApprovalRegistry;
     MockPermissions public feeExemptionWhitelist;
-    IBullaFrendLendV2 public bullaFrendLend;
     IBullaClaimV2 public bullaClaim;
     IBullaInvoice public bullaInvoice;
 
@@ -78,9 +75,8 @@ contract CommonSetup is Test, BatchTestHelpers {
         bullaControllerRegistry = new BullaControllerRegistry();
         bullaApprovalRegistry = new BullaApprovalRegistry(address(bullaControllerRegistry));
         bullaClaim = new BullaClaimV2(address(bullaApprovalRegistry), LockState.Unlocked, 0, address(feeExemptionWhitelist));
-        bullaFrendLend = new BullaFrendLendV2(address(bullaClaim), address(this), 50, 0);
         bullaInvoice = new BullaInvoice(address(bullaClaim), address(this), 50);
-        invoiceAdapterBulla = new BullaClaimV2InvoiceProviderAdapterV2(address(bullaClaim), address(bullaFrendLend), address(bullaInvoice));
+        invoiceAdapterBulla = new BullaClaimV2InvoiceProviderAdapterV2(address(bullaClaim), address(bullaInvoice));
         bullaApprovalRegistry.setAuthorizedContract(address(bullaClaim), true);
         
         address[] memory safeOwners = new address[](2);

--- a/test/foundry/TestBullaFactoringFactoryV2_1.t.sol
+++ b/test/foundry/TestBullaFactoringFactoryV2_1.t.sol
@@ -13,8 +13,6 @@ import { MockPermissions } from 'contracts/mocks/MockPermissions.sol';
 import { MockZodiacRoles } from 'contracts/mocks/MockZodiacRoles.sol';
 import { IZodiacRoles } from 'contracts/interfaces/IZodiacRoles.sol';
 import { IInvoiceProviderAdapterV2 } from 'contracts/interfaces/IInvoiceProviderAdapter.sol';
-import { IBullaFrendLendV2 } from 'bulla-contracts-v2/src/interfaces/IBullaFrendLendV2.sol';
-import { BullaFrendLendV2 } from 'bulla-contracts-v2/src/BullaFrendLendV2.sol';
 import { BullaControllerRegistry } from 'bulla-contracts-v2/src/BullaControllerRegistry.sol';
 import { BullaClaimV2 } from 'bulla-contracts-v2/src/BullaClaimV2.sol';
 import { BullaApprovalRegistry } from 'bulla-contracts-v2/src/BullaApprovalRegistry.sol';
@@ -35,7 +33,6 @@ contract TestBullaFactoringFactoryV2_1 is Test {
     
     BullaControllerRegistry public bullaControllerRegistry;
     BullaApprovalRegistry public bullaApprovalRegistry;
-    IBullaFrendLendV2 public bullaFrendLend;
     IBullaClaimV2 public bullaClaim;
     BullaInvoice public bullaInvoice;
 
@@ -81,9 +78,8 @@ contract TestBullaFactoringFactoryV2_1 is Test {
         bullaControllerRegistry = new BullaControllerRegistry();
         bullaApprovalRegistry = new BullaApprovalRegistry(address(bullaControllerRegistry));
         bullaClaim = new BullaClaimV2(address(bullaApprovalRegistry), LockState.Unlocked, 0, address(feeExemptionWhitelist));
-        bullaFrendLend = new BullaFrendLendV2(address(bullaClaim), address(this), 50, 0);
         bullaInvoice = new BullaInvoice(address(bullaClaim), address(this), 50);
-        invoiceAdapter = new BullaClaimV2InvoiceProviderAdapterV2(address(bullaClaim), address(bullaFrendLend), address(bullaInvoice));
+        invoiceAdapter = new BullaClaimV2InvoiceProviderAdapterV2(address(bullaClaim), address(bullaInvoice));
         bullaApprovalRegistry.setAuthorizedContract(address(bullaClaim), true);
 
         // Compute init bytecode config for BullaFactoringV2_2
@@ -578,7 +574,7 @@ contract TestBullaFactoringFactoryV2_1 is Test {
         
         // Create a different adapter
         BullaClaimV2InvoiceProviderAdapterV2 wrongAdapter = new BullaClaimV2InvoiceProviderAdapterV2(
-            address(bullaClaim), address(bullaFrendLend), address(bullaInvoice)
+            address(bullaClaim), address(bullaInvoice)
         );
         
         // Build bytecode with wrong adapter
@@ -715,7 +711,7 @@ contract TestBullaFactoringFactoryV2_1 is Test {
 
     function test_setInvoiceProviderAdapter_updatesAdapter() public {
         BullaClaimV2InvoiceProviderAdapterV2 newAdapter = new BullaClaimV2InvoiceProviderAdapterV2(
-            address(bullaClaim), address(bullaFrendLend), address(bullaInvoice)
+            address(bullaClaim), address(bullaInvoice)
         );
 
         vm.prank(bullaDao);

--- a/test/foundry/TestRedemptionQueueInsufficientFunds.t.sol
+++ b/test/foundry/TestRedemptionQueueInsufficientFunds.t.sol
@@ -36,23 +36,6 @@ contract TestRedemptionQueueInsufficientFunds is CommonSetup {
         factoringPermissions.allow(alice);
         factoringPermissions.allow(charlie);
 
-        // Set up permitCreateClaim for Bob
-        bullaClaim.approvalRegistry().permitCreateClaim({
-            user: bob,
-            controller: address(bullaFrendLend),
-            approvalType: CreateClaimApprovalType.Approved,
-            approvalCount: type(uint64).max,
-            isBindingAllowed: true,
-            signature: sigHelper.signCreateClaimPermit({
-                pk: bobPK,
-                user: bob,
-                controller: address(bullaFrendLend),
-                approvalType: CreateClaimApprovalType.Approved,
-                approvalCount: type(uint64).max,
-                isBindingAllowed: true
-            })
-        });
-
         // Setup david and eve with more tokens
         deal(address(asset), david, 100000000);
         deal(address(asset), eve, 100000000);

--- a/test/foundry/TestRedemptionQueueIntegration.t.sol
+++ b/test/foundry/TestRedemptionQueueIntegration.t.sol
@@ -28,23 +28,6 @@ contract TestRedemptionQueueIntegration is CommonSetup {
         factoringPermissions.allow(alice);
         factoringPermissions.allow(charlie);
 
-        // Set up permitCreateClaim for Bob to create loans via BullaFrendLend
-        bullaClaim.approvalRegistry().permitCreateClaim({
-            user: bob,
-            controller: address(bullaFrendLend),
-            approvalType: CreateClaimApprovalType.Approved,
-            approvalCount: type(uint64).max,
-            isBindingAllowed: true,
-            signature: sigHelper.signCreateClaimPermit({
-                pk: bobPK,
-                user: bob,
-                controller: address(bullaFrendLend),
-                approvalType: CreateClaimApprovalType.Approved,
-                approvalCount: type(uint64).max,
-                isBindingAllowed: true
-            })
-        });
-
         // Setup additional test users with asset
         deal(address(asset), david, 10000000);
         deal(address(asset), eve, 10000000);


### PR DESCRIPTION
## Summary

- Removes all BullaFrendLend code paths from `BullaClaimV2InvoiceProviderAdapterV2` (import, state variable, constructor param, routing branches)
- Updates deploy scripts (`DeployAdapter`, `DeployBullaFactoring`, `DeployBullaFactoringFactory`) to remove FrendLend address from adapter construction and config structs
- Removes FrendLend imports, state variables, and unused `permitCreateClaim` setup from test files

FrendLend whitelisting callback is not needed in v2.2 since loan offer functionality was removed in #224.

## Test plan
- [x] Build passes (23,500 bytes, 1,076 margin)
- [x] 642/642 non-fork tests pass
- [ ] CI passes