### PR TITLE
fix(impairment): remove double-count of insurance payout on recovery

### DIFF
--- a/contracts/BullaFactoring.sol
+++ b/contracts/BullaFactoring.sol
@@ -629,8 +629,11 @@ contract BullaFactoringV2_2 is IBullaFactoringV2_2, ERC20, ERC4626, Ownable {
             // investorShare is realised profit (interest) above insurance purchase price
             paidInvoicesGain += investorShare;
 
-            // Reverse the net principal loss now that the invoice has been recovered.
-            impairmentLosses -= _impairment.principalLoss;
+            // NOTE: impairmentLosses is intentionally NOT reversed here.
+            // The principal loss recorded at impairment was already offset by the insurance
+            // payout (lpCredit). Reversing it would double-count: LPs would get credit for
+            // the recovered principal AND the insurance payout that already reduced their loss.
+            // The LP's only benefit from recovery is investorShare (above).
 
             delete impairmentInfo[invoiceId];
 

--- a/test/foundry/TestInsurance.t.sol
+++ b/test/foundry/TestInsurance.t.sol
@@ -1007,23 +1007,19 @@ contract TestInsurance is CommonSetup {
             "Capital account should increase after full repayment of impaired invoice"
         );
 
-        // After full repayment, LPs should have recovered most of their capital.
-        // The pool originally funded 80,000 gross. The debtor repaid 100,000.
-        // Of the 100,000 recovered:
-        //   - Insurance gets back purchasePrice (5,000) + 50% of excess (47,500) = 52,500
-        //   - LPs get 50% of excess = 47,500
+        // After full repayment, LPs recover only their profit share of excess
+        // above the insurance purchase price. The impairment loss is NOT reversed
+        // because the insurance payout that reduced it at impairment time flows
+        // back to the insurer at recovery (via insuranceShare), not to LPs.
         //
         // Net LP position over the full lifecycle (impair + recover):
-        //   At impairment: loss recognized (capital account decreases)
-        //   At recovery: gain of investorShare = 47,500
-        //   Net: LPs should be ahead of where they started (they funded 80,000
-        //         and get back the original capital + 47,500 profit share of recovery)
-        //
-        // The capital account after full recovery should be HIGHER than before impairment,
-        // because the recovery profit (investorShare) exceeds any residual accounting cost.
+        //   At impairment: loss = principalLoss (fundedAmountNet - lpCredit)
+        //   At recovery: gain = investorShare (50% of excess above purchasePrice)
+        //   Net: LPs bear a loss because principalLoss > investorShare.
+        //   This is correct — insurance takes the majority of recovery proceeds.
         assertTrue(
-            capitalAccountAfterRepay > capitalAccountBefore,
-            "After full recovery, capital account should exceed pre-impairment level"
+            capitalAccountAfterRepay < capitalAccountBefore,
+            "After full recovery, capital account should be below pre-impairment level (insurance takes majority of recovery)"
         );
 
         emit log_named_uint("Final capitalAccount", capitalAccountAfterRepay);


### PR DESCRIPTION
https://github.com/LPHAC/bulla-4-factoring/issues/12

## Summary

• Removes the `impairmentLosses -= principalLoss` line from the recovery path in `reconcileSingleInvoice`, which double-counted the insurance payout — crediting LPs for recovered principal that actually flows back to the insurer via `insuranceShare`
• After this fix, LP recovery from impaired invoices comes solely through `investorShare` (profit share of excess above purchase price), while `impairmentLosses` correctly remains unchanged
• Updates test assertion to verify capital account stays below pre-impairment level after full recovery

## The Bug

At impairment, insurance pays `impairmentGrossGain` which reduces LP's `principalLoss`. At recovery, the same payout flows back to the insurer (via `insuranceShare`), but the code also reversed `impairmentLosses` by `principalLoss` — effectively crediting LPs twice for the same insurance money. This created phantom LP capital with no cash backing, leading to pool insolvency.

## Test Plan

• `testImpairmentCapitalAccountAndPricePerShare` validates the corrected accounting
• Full test suite: 681 passed, 0 failed