### PR TITLE
fix(impairment): credit surplus to paidInvoicesGain instead of stranding it

### DIFF
--- a/contracts/BullaFactoring.sol
+++ b/contracts/BullaFactoring.sol
@@ -999,10 +999,15 @@ contract BullaFactoringV2_2 is IBullaFactoringV2_2, ERC20, ERC4626, Ownable {
         // paidInvoicesGain is not touched — it tracks only realised interest.
         uint256 paymentsSinceFunding = currentPaidAmount - _approval.initialPaidAmount;
         uint256 credited = lpCredit + paymentsSinceFunding;
-        uint256 _principalLoss = _approval.fundedAmountGross > credited
-            ? _approval.fundedAmountGross - credited
-            : 0;
-        impairmentLosses += _principalLoss;
+        uint256 _principalLoss;
+        if (_approval.fundedAmountGross > credited) {
+            _principalLoss = _approval.fundedAmountGross - credited;
+            impairmentLosses += _principalLoss;
+        } else {
+            // credited exceeds the gross funded exposure: the invoice was net-profitable at
+            // impairment. Recognise the surplus as an LP gain instead of stranding it.
+            paidInvoicesGain += credited - _approval.fundedAmountGross;
+        }
         impairmentInfo[invoiceId] = ImpairmentInfo({
             isImpaired: true,
             purchasePrice: _impairmentGrossGain,

--- a/test/foundry/TestInsurance.t.sol
+++ b/test/foundry/TestInsurance.t.sol
@@ -1311,8 +1311,9 @@ contract TestInsurance is CommonSetup {
         // repaid in principal. There is no principal loss.
         assertEq(impairmentLosses, 0, "principalLoss should be 0 when payments exceed funded amount");
 
-        // paidInvoicesGain should still be 0 (interest only)
-        assertEq(bullaFactoring.paidInvoicesGain(), 0, "paidInvoicesGain unchanged - interest only");
+        // Payments exceed fundedAmountGross, so the surplus is recognised as LP gain
+        // rather than being silently dropped (stranded).
+        assertTrue(bullaFactoring.paidInvoicesGain() > 0, "surplus credited to paidInvoicesGain");
 
         // Capital account should not decrease — pool is fully repaid
         assertTrue(

--- a/test/foundry/TestInsurance.t.sol
+++ b/test/foundry/TestInsurance.t.sol
@@ -1575,3 +1575,59 @@ contract TestInsurance is CommonSetup {
         assertEq(asset.balanceOf(address(bullaFactoring)), 0, "pool token balance should be zero after full wind-down");
     }
 }
+
+contract TestImpairmentSurplusRegression is CommonSetup {
+    address insurerAddr = address(0x1999);
+
+    function _windDownAndAssertEmpty(string memory tag) internal {
+        if (bullaFactoring.insuranceBalance() > 0) { vm.prank(insurerAddr); bullaFactoring.withdrawInsuranceBalance(); }
+        uint256 shares = bullaFactoring.maxRedeem(alice);
+        if (shares > 0) { vm.prank(alice); bullaFactoring.redeem(shares, alice, alice); }
+        if (bullaFactoring.protocolFeeBalance() > 0) bullaFactoring.withdrawProtocolFees();
+        if (bullaFactoring.adminFeeBalance() > 0) { vm.prank(bullaFactoring.owner()); bullaFactoring.withdrawAdminFeesAndSpreadGains(); }
+        assertEq(bullaFactoring.balanceOf(alice), 0, string.concat(tag, ": alice fully redeemed"));
+        assertEq(bullaFactoring.calculateCapitalAccount(), 0, string.concat(tag, ": capital account zero"));
+        assertEq(asset.balanceOf(address(bullaFactoring)), 0, string.concat(tag, ": no stranded cash"));
+    }
+
+    // Default insurance params. Invoice paid 90k (> ~80k gross) then impaired -> surplus.
+    function testMostlyPaidThenImpairedCreditsSurplus() public {
+        asset.mint(insurerAddr, 1_000_000); vm.prank(insurerAddr); asset.approve(address(bullaFactoring), type(uint256).max);
+        vm.prank(alice); bullaFactoring.deposit(1_000_000, alice);
+        vm.prank(bob); uint256 id = createClaim(bob, charlie, 100_000, dueBy);
+        vm.prank(underwriter); _approveInvoice(id, interestApr, spreadBps, upfrontBps, 0);
+        vm.startPrank(bob); bullaClaim.approve(address(bullaFactoring), id); _fundInvoice(id, upfrontBps, address(0)); vm.stopPrank();
+        vm.startPrank(charlie); asset.approve(address(bullaClaim), 90_000); bullaClaim.payClaim(id, 90_000); vm.stopPrank();
+        vm.warp(block.timestamp + 91 days);
+        vm.prank(insurerAddr); bullaFactoring.impairInvoice(id);
+        _windDownAndAssertEmpty("mostly-paid");
+    }
+
+    // High impairmentGrossGainBps (100%), impaired unpaid then fully recovered.
+    function testHighGrossGainImpairThenRecoverStaysClean() public {
+        asset.mint(insurerAddr, 10_000_000); vm.prank(insurerAddr); asset.approve(address(bullaFactoring), type(uint256).max);
+        bullaFactoring.setInsuranceParams(uint16(100), uint16(10000), uint16(5000));
+        vm.prank(alice); bullaFactoring.deposit(1_000_000, alice);
+        vm.prank(bob); uint256 id = createClaim(bob, charlie, 100_000, dueBy);
+        vm.prank(underwriter); _approveInvoice(id, interestApr, spreadBps, upfrontBps, 0);
+        vm.startPrank(bob); bullaClaim.approve(address(bullaFactoring), id); _fundInvoice(id, upfrontBps, address(0)); vm.stopPrank();
+        vm.warp(block.timestamp + 91 days);
+        vm.prank(insurerAddr); bullaFactoring.impairInvoice(id);
+        // full recovery
+        vm.startPrank(charlie); asset.approve(address(bullaClaim), 100_000); bullaClaim.payClaim(id, 100_000); vm.stopPrank();
+        _windDownAndAssertEmpty("high-grossgain-recover");
+    }
+
+    // High impairmentGrossGainBps (100%), impaired unpaid, never recovers.
+    function testHighGrossGainImpairNoRecoveryStaysClean() public {
+        asset.mint(insurerAddr, 10_000_000); vm.prank(insurerAddr); asset.approve(address(bullaFactoring), type(uint256).max);
+        bullaFactoring.setInsuranceParams(uint16(100), uint16(10000), uint16(5000));
+        vm.prank(alice); bullaFactoring.deposit(1_000_000, alice);
+        vm.prank(bob); uint256 id = createClaim(bob, charlie, 100_000, dueBy);
+        vm.prank(underwriter); _approveInvoice(id, interestApr, spreadBps, upfrontBps, 0);
+        vm.startPrank(bob); bullaClaim.approve(address(bullaFactoring), id); _fundInvoice(id, upfrontBps, address(0)); vm.stopPrank();
+        vm.warp(block.timestamp + 91 days);
+        vm.prank(insurerAddr); bullaFactoring.impairInvoice(id);
+        _windDownAndAssertEmpty("high-grossgain-norecover");
+    }
+}


### PR DESCRIPTION
## Summary

• When `credited` (lpCredit + paymentsSinceFunding) exceeds `fundedAmountGross` at impairment, the ternary clamp (`? ... : 0`) silently dropped the surplus — leaving cash stranded in the contract with no accounting entry
• Replaced the clamp with an if/else that credits the surplus to `paidInvoicesGain`, so the capital account accurately reflects the pool's net position
• Updated `testImpairmentPaymentsExceedFundedAmountNet` to assert surplus is credited (previously asserted 0, which was the buggy behavior)

## Test plan

- [x] All 685 tests pass (`FOUNDRY_PROFILE=test forge test --no-match-contract "Fork"`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)